### PR TITLE
Implement file rename and table UI

### DIFF
--- a/auth-backend/controllers/wasabiController.js
+++ b/auth-backend/controllers/wasabiController.js
@@ -98,3 +98,25 @@ export const downloadFile = async (req, res) => {
     res.status(500).json({ error: 'Download failed' });
   }
 };
+
+export const renameFile = async (req, res) => {
+  const { oldKey, newKey } = req.body;
+  if (!oldKey || !newKey) {
+    return res.status(400).json({ error: 'Missing oldKey or newKey' });
+  }
+
+  const copyParams = {
+    Bucket: WASABI_BUCKET,
+    CopySource: `${WASABI_BUCKET}/${oldKey}`,
+    Key: newKey,
+  };
+
+  try {
+    await s3.copyObject(copyParams).promise();
+    await s3.deleteObject({ Bucket: WASABI_BUCKET, Key: oldKey }).promise();
+    res.json({ message: `Renamed ${oldKey} to ${newKey}` });
+  } catch (err) {
+    console.error('[Wasabi] Rename failed:', err);
+    res.status(500).json({ error: 'Rename failed' });
+  }
+};

--- a/auth-backend/routes/wasabi.js
+++ b/auth-backend/routes/wasabi.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import multer from 'multer';
-import { listFiles, uploadFile, deleteFile, downloadFile } from '../controllers/wasabiController.js';
+import { listFiles, uploadFile, deleteFile, downloadFile, renameFile } from '../controllers/wasabiController.js';
 
 const router = express.Router();
 const upload = multer({ dest: 'tmp/' }); // Temporary upload dir
@@ -9,5 +9,6 @@ router.get('/list', listFiles);
 router.post('/upload', upload.single('file'), uploadFile);
 router.delete('/delete', deleteFile);
 router.get('/download', downloadFile);
+router.post('/rename', renameFile);
 
 export default router;

--- a/src/pages/WasabiManager.vue
+++ b/src/pages/WasabiManager.vue
@@ -169,11 +169,14 @@ const renameFileAction = async () => {
   }
 }
 
+const BYTES_IN_KB = 1024;
+const BYTES_IN_MB = 1024 * 1024;
+
 const formatSize = (size) => {
-  if (size > 1024 * 1024) {
-    return (size / (1024 * 1024)).toFixed(2) + ' MB'
+  if (size > BYTES_IN_MB) {
+    return (size / BYTES_IN_MB).toFixed(2) + ' MB'
   }
-  return (size / 1024).toFixed(2) + ' KB'
+  return (size / BYTES_IN_KB).toFixed(2) + ' KB'
 }
 
 onMounted(fetchFiles)


### PR DESCRIPTION
## Summary
- replace file list with a `v-data-table` and add actions
- implement file download and rename in WasabiManager
- add backend API to rename objects in Wasabi
- expose `/wasabi/rename` route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686f40f4c0dc8320ad08e1bc7bfd16f9