### PR TITLE
Add API helpers for price lines and territories

### DIFF
--- a/src/api/priceLines.js
+++ b/src/api/priceLines.js
@@ -1,0 +1,30 @@
+import axios from '@/utils/axios'
+
+export const searchPriceLines = async (keyword) => {
+  const res = await axios.post('/api/erp-proxy', {
+    method: 'GET',
+    url: '/PriceLines',
+    params: {
+      keyword,
+      includeTotalItems: true,
+    },
+  })
+  return res.data
+}
+
+export const getPriceLine = async (id) => {
+  const res = await axios.post('/api/erp-proxy', {
+    method: 'GET',
+    url: `/PriceLines/${id}`,
+  })
+  return res.data
+}
+
+export const updatePriceLine = async (id, data) => {
+  const res = await axios.post('/api/erp-proxy', {
+    method: 'PUT',
+    url: `/PriceLines/${id}`,
+    data,
+  })
+  return res.data
+}

--- a/src/api/territories.js
+++ b/src/api/territories.js
@@ -1,0 +1,9 @@
+import axios from '@/utils/axios'
+
+export const getTerritory = async (id) => {
+  const res = await axios.post('/api/erp-proxy', {
+    method: 'GET',
+    url: `/Territories/${id}`,
+  })
+  return res.data
+}


### PR DESCRIPTION
## Summary
- add `searchPriceLines`, `getPriceLine`, and `updatePriceLine` helpers
- add `getTerritory` API helper

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686f411bce5c83209d595a96e0531454